### PR TITLE
Bring extended documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+docs

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# boringproxy.io
+
+This repository contains the source files for the boringproxy.io website.
+
+Build it with
+
+```bash
+npm i
+npm run build          # builds into the current directory
+npm run build docs     # builds into the docs subdirectory
+```
+
+If your system comes with the `entr` command, you can rebuild the site on file changes.
+
+```bash
+npm run watch          # builds and watches for file changes
+npm run watch docs     # builds to docs and watches for file changes
+```
+
+Sometimes you need to start your build from scratch.
+
+```bash
+npm run clean          # cleans selected files in the current directory
+npm run clean docs     # cleans the docs directory
+```
+
+See all build jobs and their specifications with `npm run.`

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $1 != "" ]]
+then
+    [[ $1 = \/* ]] && echo "We don't work in / or below, aborting." && exit
+    echo "Cleaning up $1"
+    rm -rf $1
+else
+    echo "Cleaning up files"
+    rm -rf index.html mission tunneling-comparison usage
+fi

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node ssg.js",
+    "watch": "./watch-build.sh",
+    "clean": "./clean.sh"
   },
   "author": "",
   "license": "ISC",

--- a/pages/index.md
+++ b/pages/index.md
@@ -76,7 +76,7 @@ sudo setcap cap_net_bind_service=+ep boringproxy
 
 The clients will then be able to assign domains from the wildcard subdomain without having to reconfigure DNS beforehand.
 
-## [Usage](/usage/)
+## Usage
 
 Learn more about the [usage](/usage/) in the documentation.
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -3,7 +3,7 @@
 You're using it right now! The website you're reading is hosted on my home
 computer, through boringproxy.
 
-boringproxy is a combination reverse proxy and tunnel manager.
+`boringproxy` is a combination of reverse proxy and tunnel manager.
 
 What that means is if you have a self-hosted web service (Nextcloud, Emby,
 Jellyfin, etherpad, personal website, etc) running on a private network (such as behind a
@@ -29,19 +29,7 @@ The main features are:
 * Ships as single executable which contains both the server and client.
 * SSH under the hood. You can use a standard SSH client if you prefer.
 
-# Server Installation
-
-```bash
-curl -LO https://github.com/boringproxy/boringproxy/releases/download/v0.1.0/boringproxy
-
-# Make executable
-chmod +x boringproxy
-
-# Allow binding to ports 80 and 443
-sudo setcap cap_net_bind_service=+ep boringproxy
-```
-
-# Demo Video
+## Demo Video
 
 <a href='https://www.youtube.com/watch?v=-kACP0X6E-I'>YouTube mirror</a>
 <a href='/demo.webm' download='boringproxy_demo.webm'>Download WebM/VP9</a>
@@ -53,8 +41,7 @@ sudo setcap cap_net_bind_service=+ep boringproxy
   Sorry, your browser doesn't support embedded videos.
 </video>
 
-
-# Demo Instance
+## Demo Instance
 
 There is a demo instance at `https://bpdemo.brng.pro`. If you submit your email
 address using the form below, it will create an account for you and send you
@@ -66,8 +53,34 @@ a login link so you can create tunnels.
   <input type='submit' class='button'>
 </form>
 
+## Installation
 
-# What's with the name?
+The program is shipped in one binary that acts both as a server and a client.
+
+Acquire it as below:
+
+```bash
+curl -LO https://github.com/boringproxy/boringproxy/releases/download/v0.1.0/boringproxy
+
+# Make executable
+chmod +x boringproxy
+
+# Allow binding to ports 80 and 443
+sudo setcap cap_net_bind_service=+ep boringproxy
+```
+
+`boringproxy` uses the DNS to identify the server and the tunnel endpoints. An often used pattern is to provide a domain record for the administrative web interface, and a wildcard subdomain for the tunneled services.
+
+* `bpdemo.brng.pro` - the fully qualified domain name (FQDN) of the host where boringproxy will be running.
+* `*.bpdemo.brng.pro` - a wildcard subdomain for effortless domain mapping of clients
+
+The clients will then be able to assign domains from the wildcard subdomain without having to reconfigure DNS beforehand.
+
+## [Usage](/usage/)
+
+Learn more about the [usage](/usage/) in the documentation.
+
+## What's with the name?
 
 The name has two meanings; one pun and one philosophy. The pun is "bore" as in
 bore a hole/tunnel, highlighting the fact that boringproxy is a reverse proxy
@@ -82,6 +95,4 @@ This also has implications when it comes to adding features. I want boringproxy
 to remain simple and focused. When contemplating adding any feature, the first
 question I ask myself is: is it boring enough?
 
-
 [NAT]: https://en.wikipedia.org/wiki/Network_address_translation
-

--- a/pages/index.md
+++ b/pages/index.md
@@ -3,7 +3,7 @@
 You're using it right now! The website you're reading is hosted on my home
 computer, through boringproxy.
 
-`boringproxy` is a combination of reverse proxy and tunnel manager.
+`boringproxy` is a combination of a reverse proxy and a tunnel manager.
 
 What that means is if you have a self-hosted web service (Nextcloud, Emby,
 Jellyfin, etherpad, personal website, etc) running on a private network (such as behind a
@@ -55,7 +55,7 @@ a login link so you can create tunnels.
 
 ## Installation
 
-The program is shipped in one binary that acts both as a server and a client.
+The program is shipped in one executable file that acts both as the server and the client.
 
 Acquire it as below:
 

--- a/pages/usage.md
+++ b/pages/usage.md
@@ -1,0 +1,85 @@
+# Usage
+
+`boringproxy` consists of two kinds of long running processes that act as server and client.
+
+They can be invoked directly on the shell or in a tmux session, or be configured to run as system daemons.
+
+It is managed via an administrative web interface.
+
+## Command line interface
+
+The command line interface is used to create server and client instances.
+
+## Server
+
+The server requires you to pass the domain it will serve. It is invoked with:
+
+```bash
+./boringproxy server -admin-domain <FQDN>
+```
+
+* `FQDN` - the main domain configured in DNS
+
+> Example:
+> 
+> `boringproxy server -admin-domain bpdemo.brng.pro`
+
+Upon first run a configuration file `boringproxy_db.json` with admin credentials will be created and a login link is displayed.
+
+* `https://<FQDN>/login?access_token=<TOKEN>`
+
+> Example:
+> 
+> `https://bpdemo.brng.pro/login?access_token=yJaicLl6zj48zZItXvtQGb4CH5m5fId5`
+
+## Client
+
+The client needs to know which server to connect to, a valid combination of user and access token plus a unique name for the current client. You can start it with:
+
+```bash
+./boringproxy client -server <FQDN> -user <USER> -token <TOKEN> -client-name <CLIENT>
+```
+
+* `FQDN` - the domain of the remote server
+* `USER` - username, min. six characters, if not admin
+* `TOKEN` - access token to authenticate against the service
+* `CLIENT` - identifier for the client, used in the interface to distinguish the available tunnel origins
+
+> Example:
+> 
+> `boringproxy client -server bpdemo.brng.pro -token fKFIjefKDFLEFijKDFJKELJF -client-name demo-client -user demo-user`
+
+## Web interface
+
+The web interface is used to manage users, access tokens and tunnels.
+
+Access it at `https://<FQDN>/` where you will be presented with a prompt for a token, or with the direct login link from above.
+
+> ![](./../screenshot.png)
+>
+> Web interface after logging in as admin.
+
+### Tunnels
+
+The tunnels pane allows to create and remove tunnels. It offers you to specify the settings of a tunnel:
+
+- **Domain** - 
+- **Client Name** - 
+- **Client Address** - 
+- **Client Port** - 
+- **Allow External TCP** - 
+- **Password Protect** - 
+
+### Tokens
+
+The tokens pane allows to create and remove tokens for your current user.  
+Multiple tokens per user can be issued.  
+Administrators can manage the tokens of all users.
+
+### Users
+
+The users pane allows users with administrative priviledge to add and remove users.
+
+## HTTP API
+
+There is an experimental HTTP API, that is being used internally by the web interface. Authentication details and routes will become documented when its API stabilises.

--- a/pages/usage.md
+++ b/pages/usage.md
@@ -26,7 +26,7 @@ Example:
 boringproxy server -admin-domain bpdemo.brng.pro
 ```
 
-Upon first run a configuration file `boringproxy_db.json` with admin credentials will be created and a login link is displayed that looks like:
+Upon first run a simple text database file `boringproxy_db.json` with admin credentials will be created and a login link is displayed that looks like:
 
 > `https://<FQDN>/login?access_token=<TOKEN>`
 
@@ -74,7 +74,7 @@ Access it at `https://<FQDN>/` where you will be presented with a prompt for a t
 
 ### Tunnels
 
-The tunnels pane allows to create and remove tunnels. It offers you to specify the settings of a tunnel:
+The tunnels pane allows creating and removing tunnels. It provides a way for you to specify the settings of a tunnel:
 
 * **Domain**  
   The FQDN of a domain pointing at the `boringproxy` server. With DNS wildcard setup, this can be any subdomain of the `admin-domain`.

--- a/pages/usage.md
+++ b/pages/usage.md
@@ -2,9 +2,11 @@
 
 `boringproxy` consists of two kinds of long running processes that act as server and client.
 
-They can be invoked directly on the shell or in a tmux session, or be configured to run as system daemons.
+Run it in the shell, with `bg`/`fg`, in a tmux session, or configure a system daemon.
 
 It is managed via an administrative web interface.
+
+---
 
 ## Command line interface
 
@@ -14,40 +16,51 @@ The command line interface is used to create server and client instances.
 
 The server requires you to pass the domain it will serve. It is invoked with:
 
-```bash
-./boringproxy server -admin-domain <FQDN>
+> `./boringproxy server -admin-domain <admin-domain>`
+
+> `-admin-domain` - the main domain configured in DNS
+
+Example:
+
+```
+boringproxy server -admin-domain bpdemo.brng.pro
 ```
 
-* `FQDN` - the main domain configured in DNS
+Upon first run a configuration file `boringproxy_db.json` with admin credentials will be created and a login link is displayed that looks like:
 
-> Example:
-> 
-> `boringproxy server -admin-domain bpdemo.brng.pro`
+> `https://<FQDN>/login?access_token=<TOKEN>`
 
-Upon first run a configuration file `boringproxy_db.json` with admin credentials will be created and a login link is displayed.
+Example:
 
-* `https://<FQDN>/login?access_token=<TOKEN>`
-
-> Example:
-> 
-> `https://bpdemo.brng.pro/login?access_token=yJaicLl6zj48zZItXvtQGb4CH5m5fId5`
+```
+https://bpdemo.brng.pro/login?access_token=yJaicLl6zj48zZItXvtQGb4CH5m5fId5
+```
 
 ## Client
 
 The client needs to know which server to connect to, a valid combination of user and access token plus a unique name for the current client. You can start it with:
 
 ```bash
-./boringproxy client -server <FQDN> -user <USER> -token <TOKEN> -client-name <CLIENT>
+./boringproxy client \
+    -server <server> -user <user> -token <token> -client-name <client-name>
 ```
 
-* `FQDN` - the domain of the remote server
-* `USER` - username, min. six characters, if not admin
-* `TOKEN` - access token to authenticate against the service
-* `CLIENT` - identifier for the client, used in the interface to distinguish the available tunnel origins
+> `-server` - the domain of the remote server  
+> `-user` - username, min. six characters, if not admin  
+> `-token` - access token to authenticate against the service  
+> `-client-name` - identifier for the client, used in the interface to distinguish the available tunnel origins  
 
-> Example:
-> 
-> `boringproxy client -server bpdemo.brng.pro -token fKFIjefKDFLEFijKDFJKELJF -client-name demo-client -user demo-user`
+Example:
+
+```
+boringproxy client \
+    -server bpdemo.brng.pro \
+    -token fKFIjefKDFLEFijKDFJKELJF \
+    -client-name demo-client \
+    -user demo-user
+```
+
+---
 
 ## Web interface
 
@@ -63,16 +76,22 @@ Access it at `https://<FQDN>/` where you will be presented with a prompt for a t
 
 The tunnels pane allows to create and remove tunnels. It offers you to specify the settings of a tunnel:
 
-- **Domain** - 
-- **Client Name** - 
-- **Client Address** - 
-- **Client Port** - 
-- **Allow External TCP** - 
-- **Password Protect** - 
+* **Domain**  
+  The FQDN of a domain pointing at the `boringproxy` server. With DNS wildcard setup, this can be any subdomain of the `admin-domain`.
+* **Client Name**  
+  Choose a connected client as tunnel partner
+* **Client Address**  
+  The forwarding target as seen from the client
+* **Client Port**  
+  The port forwarding to
+* **Allow External TCP**  
+  Enable raw TCP tunneling for other protocols than HTTP
+* **Password Protect**  
+  Enable to set username and password for HTTP basic auth
 
 ### Tokens
 
-The tokens pane allows to create and remove tokens for your current user.  
+The tokens pane allows to create and remove tokens for your currently logged in user.  
 Multiple tokens per user can be issued.  
 Administrators can manage the tokens of all users.
 
@@ -80,6 +99,8 @@ Administrators can manage the tokens of all users.
 
 The users pane allows users with administrative priviledge to add and remove users.
 
+---
+
 ## HTTP API
 
-There is an experimental HTTP API, that is being used internally by the web interface. Authentication details and routes will become documented when its API stabilises.
+There is an experimental HTTP API, that is being used internally by the web interface. Authentication details and routes will become available when its public interface stabilises.

--- a/ssg.js
+++ b/ssg.js
@@ -13,7 +13,8 @@ marked.setOptions({
 });
 
 const inDir = './';
-const outDir = './';
+const outDir = (process.argv.length !== 3) ? './' : `./${process.argv[2]}/`;
+fs.mkdirSync(outDir, { recursive: true });
 
 const partialsDir = path.join(inDir, 'partials');
 
@@ -44,4 +45,10 @@ for (const pageMd of pagesFiles) {
   }
 
   fs.writeFileSync(path.join(htmlDir, 'index.html'), htmlText);
+}
+
+if (outDir != './') {
+  for (file of ["styles.css", "logo.svg", "screenshot.png"]) {
+    fs.copyFileSync(`${file}`, path.join(outDir, file))
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -63,3 +63,7 @@ pre {
 
 .big-font {
 }
+
+img {
+  max-width: 100%;
+}

--- a/watch-build.sh
+++ b/watch-build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ls pages/* partials/* | entr ./ssg.js
+ls pages/* partials/* | entr ./ssg.js $1


### PR DESCRIPTION
After touching the current prerelease of `boringproxy`, there was a chance to contribute to the project from outside by extending its documentation.

This is an attempt of extending the existing website with a little more details about installation and usage, plus wraps its build environment more strictly into `npm run` scripts.

Please refer to the git log and diff about the added and changed files.

Closes #1