### PR TITLE
Change outdated urls to point to latest release

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -7,7 +7,7 @@ Acquire it as below for your system:
 
 ## Linux x86_64
 ```bash
-curl -LO https://github.com/boringproxy/boringproxy/releases/download/v0.6.0/boringproxy-linux-x86_64
+curl -LO https://github.com/boringproxy/boringproxy/releases/latest/download/boringproxy-linux-x86_64
 
 # Make executable
 chmod +x boringproxy-linux-x86_64
@@ -18,7 +18,7 @@ sudo setcap cap_net_bind_service=+ep boringproxy-linux-x86_64
 
 ## Linux i386
 ```bash
-curl -LO https://github.com/boringproxy/boringproxy/releases/download/v0.6.0/boringproxy-linux-386
+curl -LO https://github.com/boringproxy/boringproxy/releases/latest/download/boringproxy-linux-386
 
 # Make executable
 chmod +x boringproxy-linux-386
@@ -28,7 +28,7 @@ sudo setcap cap_net_bind_service=+ep boringproxy-linux-386
 ```
 ## Linux ARM
 ```bash
-curl -LO https://github.com/boringproxy/boringproxy/releases/download/v0.6.0/boringproxy-linux-arm
+curl -LO https://github.com/boringproxy/boringproxy/releases/latest/download/boringproxy-linux-arm
 
 # Make executable
 chmod +x boringproxy-linux-arm
@@ -38,7 +38,7 @@ sudo setcap cap_net_bind_service=+ep boringproxy-linux-arm
 ```
 ## Linux arm64
 ```bash
-curl -LO https://github.com/boringproxy/boringproxy/releases/download/v0.6.0/boringproxy-linux-arm64
+curl -LO https://github.com/boringproxy/boringproxy/releases/latest/download/boringproxy-linux-arm64
 
 # Make executable
 chmod +x boringproxy-linux-arm64


### PR DESCRIPTION
The urls in the installation guide pointed to a very outdated version. Replace them with a link that always points to the latest version.